### PR TITLE
Run pipline

### DIFF
--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -35,7 +35,7 @@ def main(args):
         args.targets = ['umi-counts.txt', 'umi-density-plot.png', 'read-density-plot.png']
 
     # Append full path to targets.
-    targets_with_path = [args.directory / t for t in args.targets]
+    targets_with_path = [str(args.directory / t) for t in args.targets]
 
     # Check if correct file exists in output directory.
     # If not, try using the input fastq argument if given.
@@ -56,6 +56,7 @@ def main(args):
 
         # Create symbolic link to file in output directory.
         os.symlink(args.fastq, args.directory / accepted_file)
+        logging.info('Creating symbolic link for input file in output directory.')
     else:
         raise FileNotFoundError(f'Required file not found in folder or given as input.')
 

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -1,0 +1,37 @@
+"""
+Run DPS-Pro pipeline
+"""
+
+import logging
+import sys
+import pkg_resources
+from snakemake import snakemake
+
+from dbspro.utils import available_cpu_count
+
+logger = logging.getLogger(__name__)
+
+
+def main(args):
+
+    # Modified from: https://github.com/NBISweden/IgDiscover/
+    snakefile_path = pkg_resources.resource_filename('dbspro', 'Snakefile')
+    logger.root.handlers = []
+    success = snakemake(snakefile_path,
+                        snakemakepath='snakemake',  # Needed in snakemake 3.9.0
+                        dryrun=args.dryrun,
+                        cores=args.cores,
+                        printshellcmds=True,
+                        targets=args.targets if args.targets else None)
+
+    sys.exit(0 if success else 1)
+
+
+def add_arguments(parser):
+    parser.add_argument("-n", "--dryrun", default=False, action='store_true',
+                        help="Perform dry run of pipeline.")
+    parser.add_argument("-j", "--cores", "--jobs", metavar="<N>", type=int,
+                        default=available_cpu_count(),
+                        help="Maximum number of cores to run in parallel. Default: Use as manny as available.")
+    parser.add_argument('targets', nargs='*', default=[],
+                        help='File(s) to create. If omitted, the full pipeline is run.')

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -4,7 +4,6 @@ Run DPS-Pro pipeline
 
 import logging
 import os
-from pathlib import Path
 import sys
 import pkg_resources
 from snakemake import snakemake
@@ -18,47 +17,32 @@ accepted_file_ext = '.fastq.gz'
 
 
 def main(args):
-
-    cwd = Path(os.getcwd())
-
     # Check if path to output directory is absolute or make it so.
     if not os.path.isabs(args.directory):
-        args.directory = cwd / args.directory
+        args.directory = f"{os.getcwd()}/{args.directory}"
 
     # Check if directory exists. If not make one.
     if not os.path.isdir(args.directory):
         os.mkdir(args.directory)
         logging.info(f'Output directory {args.directory} created.')
 
-    # If no targets --> run whole pipeline i.e. use final file names.
-    if not args.targets:
-        args.targets = ['umi-counts.txt', 'umi-density-plot.png', 'read-density-plot.png']
-
     # Append full path to targets.
-    targets_with_path = [str(args.directory / t) for t in args.targets]
+    targets_with_path = [f"{args.directory}/{t}" for t in args.targets]
 
     # Check if correct file exists in output directory.
     # If not, try using the input fastq argument if given.
-    if os.path.isfile(args.directory / accepted_file):
-        logging.info(f'Found correct file in given directory, continuing analysis.')
-    elif args.fastq:
+    if args.fastq:
         # Check if path to output directory is absolute or make it so.
         if not os.path.isabs(args.fastq):
-            args.fastq = cwd / args.fastq
-
-        # Check if file exists.
-        if not os.path.isfile(args.fastq):
-            raise FileNotFoundError(f'File {args.fastq} not found.')
+            args.fastq = f"{os.getcwd()}/{args.fastq}"
 
         # Check if file has the correct extension
         if not str(args.fastq).endswith(accepted_file_ext):
             raise FileNotFoundError(f'File {args.fastq} is not accepted input.')
 
         # Create symbolic link to file in output directory.
-        os.symlink(args.fastq, args.directory / accepted_file)
+        os.symlink(args.fastq, f"{args.directory}/{accepted_file}")
         logging.info('Creating symbolic link for input file in output directory.')
-    else:
-        raise FileNotFoundError(f'Required file not found in folder or given as input.')
 
     # Lines below are modified from: https://github.com/NBISweden/IgDiscover/
     snakefile_path = pkg_resources.resource_filename('dbspro', 'Snakefile')
@@ -79,7 +63,8 @@ def add_arguments(parser):
     parser.add_argument("-j", "--cores", "--jobs", metavar="<N>", type=int,
                         default=available_cpu_count(),
                         help="Maximum number of cores to run in parallel. Default: Use as manny as available.")
-    parser.add_argument('targets', nargs='*', default=[], metavar='<TARGETS>',
+    parser.add_argument('targets', nargs='*', metavar='<TARGETS>',
+                        default=['umi-counts.txt', 'umi-density-plot.png', 'read-density-plot.png'],
                         help='File(s) to create excluding paths). If omitted, the full pipeline is run.')
     parser.add_argument('-d', '--directory', default=os.getcwd(), type=Path, metavar='<DIRECTORY>',
                         help='Path to directory in which to run pipeline and store output. Should contain input '

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -4,7 +4,7 @@ Run DPS-Pro pipeline
 
 import logging
 import os
-import shutil
+from pathlib import Path
 import sys
 import pkg_resources
 from snakemake import snakemake
@@ -13,19 +13,53 @@ from dbspro.utils import available_cpu_count
 
 logger = logging.getLogger(__name__)
 
+accepted_file = 'reads.fastq.gz'
+accepted_file_ext = '.fastq.gz'
+
 
 def main(args):
+
+    cwd = Path(os.getcwd())
+
+    # Check if path to output directory is absolute or make it so.
+    if not os.path.isabs(args.directory):
+        args.directory = cwd / args.directory
+
+    # Check if directory exists. If not make one.
+    if not os.path.isdir(args.directory):
+        os.mkdir(args.directory)
+        logging.info(f'Output directory {args.directory} created.')
+
+    # If no targets --> run whole pipeline i.e. use final file names.
     if not args.targets:
         args.targets = ['umi-counts.txt', 'umi-density-plot.png', 'read-density-plot.png']
 
-    if os.path.isdir(args.directory):
-        if args.force and input(f'Directory {args.directory} exists. Remove? (y/n)') == 'y':
-            shutil.rmtree(args.directory)
-    else:
-        os.mkdir(args.directory)
+    # Append full path to targets.
+    targets_with_path = [args.directory / t for t in args.targets]
 
-    targets_with_path = [f'{args.directory}/{t}' for t in args.targets]
-    # Modified from: https://github.com/NBISweden/IgDiscover/
+    # Check if correct file exists in output directory.
+    # If not, try using the input fastq argument if given.
+    if os.path.isfile(args.directory / accepted_file):
+        logging.info(f'Found correct file in given directory, continuing analysis.')
+    elif args.fastq:
+        # Check if path to output directory is absolute or make it so.
+        if not os.path.isabs(args.fastq):
+            args.fastq = cwd / args.fastq
+
+        # Check if file exists.
+        if not os.path.isfile(args.fastq):
+            raise FileNotFoundError(f'File {args.fastq} not found.')
+
+        # Check if file has the correct extension
+        if not str(args.fastq).endswith(accepted_file_ext):
+            raise FileNotFoundError(f'File {args.fastq} is not accepted input.')
+
+        # Create symbolic link to file in output directory.
+        os.symlink(args.fastq, args.directory / accepted_file)
+    else:
+        raise FileNotFoundError(f'Required file not found in folder or given as input.')
+
+    # Lines below are modified from: https://github.com/NBISweden/IgDiscover/
     snakefile_path = pkg_resources.resource_filename('dbspro', 'Snakefile')
     logger.root.handlers = []
     success = snakemake(snakefile_path,
@@ -46,8 +80,8 @@ def add_arguments(parser):
                         help="Maximum number of cores to run in parallel. Default: Use as manny as available.")
     parser.add_argument('targets', nargs='*', default=[],
                         help='File(s) to create (without paths). If omitted, the full pipeline is run.')
-    parser.add_argument('-d', '--directory',
-                        help='Path to directory in which to run pipeline and store output. '
-                             'Should contain input fastq file (or symbolic link to file).')
-    parser.add_argument('-f', '--force', default=False, action='store_true',
-                        help='Force to run analysis, removes existing analysis if present.')
+    parser.add_argument('-d', '--directory', default=os.getcwd(), type=Path,
+                        help='Path to directory in which to run pipeline and store output. Should contain input '
+                             'fastq file (or symbolic link to file) unless given as argument. Default: CWD')
+    parser.add_argument('-f', '--fastq', default=None, type=str,
+                        help="Input fastq file. Should have extension '.fastq.gz'. Default: None")

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -48,6 +48,6 @@ def add_arguments(parser):
                         help='File(s) to create (without paths). If omitted, the full pipeline is run.')
     parser.add_argument('-d', '--directory',
                         help='Path to directory in which to run pipeline and store output. '
-                             'Should contain input file (or symbolic link to file).')
-    parser.add_argument('-f','--force', default=False, action='store_true',
+                             'Should contain input fastq file (or symbolic link to file).')
+    parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Force to run analysis, removes existing analysis if present.')

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -66,7 +66,7 @@ def add_arguments(parser):
     parser.add_argument('targets', nargs='*', metavar='<TARGETS>',
                         default=['umi-counts.txt', 'umi-density-plot.png', 'read-density-plot.png'],
                         help='File(s) to create excluding paths). If omitted, the full pipeline is run.')
-    parser.add_argument('-d', '--directory', default=os.getcwd(), type=Path, metavar='<DIRECTORY>',
+    parser.add_argument('-d', '--directory', default=os.getcwd(), type=str, metavar='<DIRECTORY>',
                         help='Path to directory in which to run pipeline and store output. Should contain input '
                              'fastq file (or symbolic link to file) unless given as argument. Default: CWD')
     parser.add_argument('-f', '--fastq', default=None, type=str, metavar='<FASTQ>',

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -79,10 +79,10 @@ def add_arguments(parser):
     parser.add_argument("-j", "--cores", "--jobs", metavar="<N>", type=int,
                         default=available_cpu_count(),
                         help="Maximum number of cores to run in parallel. Default: Use as manny as available.")
-    parser.add_argument('targets', nargs='*', default=[],
-                        help='File(s) to create (without paths). If omitted, the full pipeline is run.')
-    parser.add_argument('-d', '--directory', default=os.getcwd(), type=Path,
+    parser.add_argument('targets', nargs='*', default=[], metavar='<TARGETS>',
+                        help='File(s) to create excluding paths). If omitted, the full pipeline is run.')
+    parser.add_argument('-d', '--directory', default=os.getcwd(), type=Path, metavar='<DIRECTORY>',
                         help='Path to directory in which to run pipeline and store output. Should contain input '
                              'fastq file (or symbolic link to file) unless given as argument. Default: CWD')
-    parser.add_argument('-f', '--fastq', default=None, type=str,
+    parser.add_argument('-f', '--fastq', default=None, type=str, metavar='<FASTQ>',
                         help="Input fastq file. Should have extension '.fastq.gz'. Default: None")

--- a/src/dbspro/utils.py
+++ b/src/dbspro/utils.py
@@ -3,7 +3,9 @@
 import sys
 import gzip
 import logging
-
+import os
+import re
+import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -129,3 +131,118 @@ class FastqRead(object):
         :return: string.
         """
         return self.header + '\n' + self.seq  + '\n' + self.comment  + '\n' + self.qual + '\n'
+
+
+def available_cpu_count():
+    """ Number of available virtual or physical CPUs on this system, i.e.
+    user/real as output by time(1) when called with an optimally scaling
+    userspace-only program
+    Taken from: http://stackoverflow.com/a/1006301/715090
+    """
+
+    # cpuset
+    # cpuset may restrict the number of *available* processors
+    try:
+        m = re.search(r'(?m)^Cpus_allowed:\s*(.*)$',
+                      open('/proc/self/status').read())
+        if m:
+            res = bin(int(m.group(1).replace(',', ''), 16)).count('1')
+            if res > 0:
+                return res
+    except IOError:
+        pass
+
+    # Python 2.6+
+    try:
+        import multiprocessing
+        return multiprocessing.cpu_count()
+    except (ImportError, NotImplementedError):
+        pass
+
+    # https://github.com/giampaolo/psutil
+    try:
+        import psutil
+        return psutil.cpu_count()   # psutil.NUM_CPUS on old versions
+    except (ImportError, AttributeError):
+        pass
+
+    # POSIX
+    try:
+        res = int(os.sysconf('SC_NPROCESSORS_ONLN'))
+
+        if res > 0:
+            return res
+    except (AttributeError, ValueError):
+        pass
+
+    # Windows
+    try:
+        res = int(os.environ['NUMBER_OF_PROCESSORS'])
+
+        if res > 0:
+            return res
+    except (KeyError, ValueError):
+        pass
+
+    # jython
+    try:
+        from java.lang import Runtime
+        runtime = Runtime.getRuntime()
+        res = runtime.availableProcessors()
+        if res > 0:
+            return res
+    except ImportError:
+        pass
+
+    # BSD
+    try:
+        sysctl = subprocess.Popen(['sysctl', '-n', 'hw.ncpu'],
+                                  stdout=subprocess.PIPE)
+        scStdout = sysctl.communicate()[0]
+        res = int(scStdout)
+
+        if res > 0:
+            return res
+    except (OSError, ValueError):
+        pass
+
+    # Linux
+    try:
+        res = open('/proc/cpuinfo').read().count('processor\t:')
+
+        if res > 0:
+            return res
+    except IOError:
+        pass
+
+    # Solaris
+    try:
+        pseudo_devices = os.listdir('/devices/pseudo/')
+        res = 0
+        for pd in pseudo_devices:
+            if re.match(r'^cpuid@[0-9]+$', pd):
+                res += 1
+
+        if res > 0:
+            return res
+    except OSError:
+        pass
+
+    # Other UNIXes (heuristic)
+    try:
+        try:
+            dmesg = open('/var/run/dmesg.boot').read()
+        except IOError:
+            dmesgProcess = subprocess.Popen(['dmesg'], stdout=subprocess.PIPE)
+            dmesg = dmesgProcess.communicate()[0]
+
+        res = 0
+        while '\ncpu' + str(res) + ':' in dmesg:
+            res += 1
+
+        if res > 0:
+            return res
+    except OSError:
+        pass
+
+    raise Exception('Can not determine number of CPUs on this system')

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2,6 +2,8 @@
 set -xoeu pipefail
 
 rm -rf outdir
-bash DBS-Pro_automation.sh testdata/reads-10k-DBS.fastq.gz outdir
+
+dbspro run -d outdir -f testdata/reads-10k-DBS.fastq.gz
+
 m=$(cat outdir/umi-counts.txt | md5sum | cut -f 1 -d" ")
 test $m == 3c086da27caec5dd08d0da695b81b067


### PR DESCRIPTION
Created script for running pipeline without using the DBS-Pro_automation script. 

Run pipeline by calling, where outdir is the output directory containing the input file ('reads.fastq.gz') :
```
dbspro run -d outdir
```

File can also be given directly. 
```
dbspro run -d outdir -f path/to/file.fastq.fz
```
Updated tests/run.sh to match new input format.