### PR TITLE
Handle error corrections using fasta instead of fastq

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -123,7 +123,7 @@ rule abc_cluster:
 rule error_correct:
     "Combine cluster results with original files to error correct them."
     output:
-        reads="{dir}/{corr_file}-corrected.fastq"
+        reads="{dir}/{corr_file}-corrected.fasta"
     input:
         reads="{dir}/{corr_file}-raw.fastq.gz",
         clusters="{dir}/{corr_file}-clusters.txt"
@@ -142,15 +142,15 @@ rule analyze:
         umi_plot="{dir}/umi-density-plot.png",
         reads_plot="{dir}/read-density-plot.png"
     input:
-        dbs_fastq="{dir}/dbs-corrected.fastq",
-        abc_fastqs=expand("{{dir}}/{abc}-UMI-corrected.fastq", abc=abc["Barcode-sequence"])
+        dbs_fasta="{dir}/dbs-corrected.fasta",
+        abc_fastas=expand("{{dir}}/{abc}-UMI-corrected.fasta", abc=abc["Barcode-sequence"])
     log: "{dir}/analyze.log"
     threads: 20
     shell:
         "dbspro analyze"
         " -f 4"
-        " {input.dbs_fastq}"
+        " {input.dbs_fasta}"
         " {output.counts}"
         " {output.umi_plot}"
         " {output.reads_plot}"
-        " {input.abc_fastqs}"
+        " {input.abc_fastas}"

--- a/src/dbspro/cli/analyze.py
+++ b/src/dbspro/cli/analyze.py
@@ -30,7 +30,7 @@ def main(args):
         abc_names = get_names(default_tsv, args.umi_abc)
 
     bc_dict = dict()
-    with dnaio.open(args.dbs, mode="r", fileformat="fastq") as reader:
+    with dnaio.open(args.dbs, mode="r", fileformat="fasta") as reader:
         for read in tqdm(reader):
             bc_dict[read.name] = read.sequence
     logger.info(f"Finished processing DBS sequences")
@@ -42,7 +42,7 @@ def main(args):
     for current_abc in args.umi_abc:
         logger.info(f"Reading file: {current_abc}")
 
-        with dnaio.open(current_abc, mode="r", fileformat="fastq") as reader:
+        with dnaio.open(current_abc, mode="r", fileformat="fasta") as reader:
             # Loop over reads in file, where read.seq = umi
             for read in tqdm(reader):
 

--- a/src/dbspro/cli/correctfastq.py
+++ b/src/dbspro/cli/correctfastq.py
@@ -36,16 +36,12 @@ def main(args):
 
     counter = Counter()
     with dnaio.open(args.raw_fastq, mode="r", fileformat="fastq") as reader, \
-         dnaio.open(args.corr_fastq, mode="w", fileformat="fastq") as openout:
+         dnaio.open(args.corr_fasta, mode="w", fileformat="fasta") as openout:
         for read in tqdm(reader):
 
             counter['tot_reads'] += 1
             if read.sequence in err_corr:
                 read.sequence = err_corr[read.sequence]
-
-                # FIX: Possibly the sequence of the error corrected read is different from the original
-                if len(read.qualities) != len(read.sequence):
-                    read.qualities = "G"*len(read.sequence)
 
                 openout.write(read)
                 counter['corr_seqs'] += 1
@@ -61,4 +57,4 @@ def main(args):
 def add_arguments(parser):
     parser.add_argument("raw_fastq", help="Fastq file with raw sequences.")
     parser.add_argument("err_corr", help="Starcode default output with error corrected sequences.")
-    parser.add_argument("corr_fastq", help="Output file in fastq with error corrected sequences.")
+    parser.add_argument("corr_fasta", help="Output file in fasta with error corrected sequences.")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,4 +6,4 @@ rm -rf outdir
 dbspro run -d outdir -f testdata/reads-10k-DBS.fastq.gz
 
 m=$(cat outdir/umi-counts.txt | md5sum | cut -f 1 -d" ")
-test $m == ae75d387667946c51f734d4de9f843b5
+test $m == 5f64eccd8b8e67d4aa954bcceb359b70


### PR DESCRIPTION
Small fix of  issue #23.

Changed from fastq to fasta in error corrected sample files as read qualities not used and caused error when parsing with dnaio. dnaio expected qualities and sequences of identical length but as correctfastq.py writes over the raw sequence with the corrected sequence (which could be a different length) an error is raised. 

   