### PR TITLE
Run options update

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -100,7 +100,7 @@ rule dbs_cluster:
         "pigz -cd {input.reads} | starcode"
         " --print-clusters"
         " -t {threads}"
-        " -d 2"
+        " -d {config[dbs_cluster_dist]}"
         " -o {output.clusters}"
 
 rule abc_cluster:
@@ -115,7 +115,7 @@ rule abc_cluster:
         "pigz -cd {input} | starcode"
         " --print-clusters"
         " -t {threads}"
-        " -d 1"
+        " -d {config[abc_cluster_dist]}"
         " -o {output}"
 
 # DBS-Pro
@@ -148,7 +148,7 @@ rule analyze:
     threads: 20
     shell:
         "dbspro analyze"
-        " -f 4"
+        " -f {config[filter_reads]}"
         " {input.dbs_fasta}"
         " {output.counts}"
         " {output.umi_plot}"

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -50,6 +50,8 @@ def main(args):
     success = snakemake(snakefile_path,
                         snakemakepath='snakemake',  # Needed in snakemake 3.9.0
                         dryrun=args.dryrun,
+                        printdag=args.dag,
+                        quiet=False if not args.dag else True,
                         cores=args.cores,
                         printshellcmds=True,
                         targets=targets_with_path)
@@ -59,10 +61,13 @@ def main(args):
 
 def add_arguments(parser):
     parser.add_argument("-n", "--dryrun", default=False, action='store_true',
-                        help="Perform dry run of pipeline.")
+                        help="Perform dry run of pipeline. Default: False.")
+    parser.add_argument("--dag", default=False, action='store_true',
+                        help="Print the dag in the graphviz dot language. Default: False. To det output to pdf file, "
+                             "pipe output into dot as follows: '$ dbspro run --dag | dot -Tpdf > dag.pdf'")
     parser.add_argument("-j", "--cores", "--jobs", metavar="<N>", type=int,
                         default=available_cpu_count(),
-                        help="Maximum number of cores to run in parallel. Default: Use as manny as available.")
+                        help="Maximum number of cores to run in parallel. Default: Use as many as available.")
     parser.add_argument('targets', nargs='*', metavar='<TARGETS>',
                         default=['umi-counts.txt', 'umi-density-plot.png', 'read-density-plot.png'],
                         help='File(s) to create excluding paths). If omitted, the full pipeline is run.')


### PR DESCRIPTION
Related to issues #24 and #19

- Created option in run.py to make dag visualization of pipeline.
```
   $ dbspro run --dag | dot -Tpdf > dag.pdf
``` 
- Made structure to pass config parameters from the run.py script to the snakemake pipeline. Included a three new options to start with but we might wanna include more later. The parameters sent to the pipeline is stored under a separate parser group `configs` and are converted to a dictionary `configs_dict` that is passed to the snakemake command.  


Current help message:
```
usage: dbspro run [-h] [-n] [--dag] [-j <JOBS>] [-d <DIRECTORY>] [-f <FASTQ>]
                  [--dbs-cluster-dist <DISTANCE>]
                  [--abc-cluster-dist <DISTANCE>] [--filter-reads <READS>]
                  [<TARGETS> [<TARGETS> ...]]

Run DPS-Pro pipeline

positional arguments:
  <TARGETS>             File(s) to create excluding paths). If omitted, the
                        full pipeline is run.

optional arguments:
  -h, --help            show this help message and exit
  -n, --dryrun          Perform dry run of pipeline. DEFAULT: False.
  --dag                 Print the dag in the graphviz dot language. DEFAULT:
                        False. To det output to pdf file, pipe output into dot
                        as follows: '$ dbspro run --dag | dot -Tpdf > dag.pdf'
  -j <JOBS>, --cores <JOBS>, --jobs <JOBS>
                        Maximum number of cores to run in parallel. DEFAULT:
                        Use as many as available.
  -d <DIRECTORY>, --directory <DIRECTORY>
                        Path to directory in which to run pipeline and store
                        output. Should contain input fastq file (or symbolic
                        link to file) unless given as argument. DEFAULT: CWD
  -f <FASTQ>, --fastq <FASTQ>
                        Input fastq file. Should have extension '.fastq.gz'.
                        DEFAULT: None

Pipeline configs:
  --dbs-cluster-dist <DISTANCE>
                        Maximum edit distance to cluster DBS sequences in
                        Starcode. DEFAULT: 2
  --abc-cluster-dist <DISTANCE>
                        Maximum edit distance to cluster ABC sequences in
                        Starcode. DEFAULT: 1
  --filter-reads <READS>
                        Minimum reads required for an ABC to be included in
                        analysis output. DEFAULT: 4
```