### PR TITLE
Snakefile changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license="MIT",
     python_requires=">=3.6",
     package_dir={"": "src"},
-    package_data={"dbspro": ["Snakefile"]},
+    package_data={"dbspro": ["rules.smk"]},
     packages=find_namespace_packages("src"),
     entry_points={"console_scripts": ["dbspro = dbspro.__main__:main"]},
     classifiers=[

--- a/src/dbspro/Snakefile
+++ b/src/dbspro/Snakefile
@@ -1,31 +1,17 @@
 import pandas as pd
 from snakemake.utils import validate
 
+# Read sample and handles files.
 abc = pd.read_csv(config["abc_sequences"], sep='\t').set_index("Antibody-target", drop=False)
-
 handles = pd.read_csv(config["handles"], sep='\t').set_index("Name", drop=False)
+
+# Get required values
+abc_len = list(map(len, abc['Barcode-sequence']))[0]    # Assumes that all ABC are same length
+abc_umi_len = abc_len + config["umi_len"]
 
 dbs = "N"*config["dbs_len"]
 
 # Cutadapt trimming
-
-rule trim_3prime:
-    "Trim 3' end up to UMI."
-    output:
-        reads="{dir}/trimmed-3prim.fastq.gz"
-    input:
-        reads="{dir}/reads.fastq.gz"
-    log: "{dir}/log_files/cutadapt-3prime-trim.log"
-    threads: 20
-    shell:
-        "cutadapt"
-        " -a {handles[Sequence][h3]}"
-        " --discard-untrimmed"
-        " -e 0.2"
-        " -j {threads}"
-        " -o {output.reads}"
-        " {input.reads}"
-        " > {log}"
 
 rule extract_dbs:
     "Extract DBS and trim handle between DBS and ABC."
@@ -55,9 +41,11 @@ rule extract_abc_umi:
     threads: 20
     shell:
         "cutadapt"
-        " -g {handles[Sequence][h1]}{dbs}{handles[Sequence][h2]}...{handles[Sequence][h3]}"
+        " -g ^{handles[Sequence][h1]}{dbs}{handles[Sequence][h2]}...{handles[Sequence][h3]}"
         " --discard-untrimmed"
         " -e 0.2"
+        " -m {abc_umi_len}"
+        " -M {abc_umi_len}"
         " -j {threads}"
         " -o {output.reads}"
         " {input.reads}"
@@ -65,17 +53,13 @@ rule extract_abc_umi:
 
 ## ABCs
 
-def get_abc_sequnce(wildcards):
-    return abc['Barcode-sequence'][wildcards.abc]
-
-# TODO Should take length from sequence.
 rule identify_abc:
     "Identifies ABC and trims it to give ABC-specific UMI fastq files."
     output:
         reads="{dir}/{sample}-UMI-raw.fastq.gz"
     input:
         reads="{dir}/trimmed-abc.fastq.gz"
-    log: "{dir}/id-{sample}.log"
+    log: "{dir}/log_files/cutadapt-id-abc-{sample}.log"
     threads: 20
     params:
         seq = lambda wildcards: abc['Barcode-sequence'][wildcards.sample]
@@ -98,7 +82,7 @@ rule dbs_cluster:
         clusters="{dir}/dbs-clusters.txt"
     input:
         reads="{dir}/dbs-raw.fastq.gz"
-    log: "{dir}/dbs-clusters.log"
+    log: "{dir}/log_files/starcode-dbs-cluster.log"
     threads: 20
     shell:
         "pigz -cd {input.reads} | starcode"
@@ -113,7 +97,7 @@ rule abc_cluster:
         "{dir}/{sample}-UMI-clusters.txt"
     input:
         "{dir}/{sample}-UMI-raw.fastq.gz"
-    log: "{dir}/{sample}-clusters.log"
+    log: "{dir}/log_files/starcode-abc-cluster-{sample}.log"
     threads: 20
     shell:
         "pigz -cd {input} | starcode"
@@ -131,7 +115,7 @@ rule error_correct:
     input:
         reads="{dir}/{corr_file}-raw.fastq.gz",
         clusters="{dir}/{corr_file}-clusters.txt"
-    log: "{dir}/{corr_file}error-correct.log"
+    log: "{dir}/log_files/error-correct-{corr_file}.log"
     threads: 20
     shell:
         "dbspro correctfastq"
@@ -148,7 +132,7 @@ rule analyze:
     input:
         dbs_fasta="{dir}/dbs-corrected.fasta",
         abc_fastas=expand("{{dir}}/{abc}-UMI-corrected.fasta", abc=abc['Antibody-target'])
-    log: "{dir}/analyze.log"
+    log: "{dir}/log_files/analyze.log"
     threads: 20
     shell:
         "dbspro analyze"

--- a/src/dbspro/Snakefile
+++ b/src/dbspro/Snakefile
@@ -5,6 +5,8 @@ abc = pd.read_csv(config["abc_sequences"], sep='\t').set_index("Antibody-target"
 
 handles = pd.read_csv(config["handles"], sep='\t').set_index("Name", drop=False)
 
+dbs = "N"*config["dbs_len"]
+
 # Cutadapt trimming
 
 rule trim_3prime:
@@ -13,7 +15,7 @@ rule trim_3prime:
         reads="{dir}/trimmed-3prim.fastq.gz"
     input:
         reads="{dir}/reads.fastq.gz"
-    log: "{dir}/reads-3prim.log"
+    log: "{dir}/log_files/cutadapt-3prime-trim.log"
     threads: 20
     shell:
         "cutadapt"
@@ -30,8 +32,8 @@ rule extract_dbs:
     output:
         reads="{dir}/dbs-raw.fastq.gz"
     input:
-        reads="{dir}/trimmed-3prim.fastq.gz"
-    log: "{dir}/extract-dbs.log"
+        reads="{dir}/reads.fastq.gz"
+    log: "{dir}/log_files/cutadapt-extract-dbs.log"
     threads: 20
     shell:
         "cutadapt"
@@ -43,17 +45,17 @@ rule extract_dbs:
         " {input.reads}"
         " > {log}"
 
-rule trim_to_abc:
+rule extract_abc_umi:
     "Trim 3' end for coupling sequence between DBS and ABC."
     output:
         reads="{dir}/trimmed-abc.fastq.gz"
     input:
-        reads="{dir}/trimmed-3prim.fastq.gz"
-    log: "{dir}/reads-3prim.log"
+        reads="{dir}/reads.fastq.gz"
+    log: "{dir}/log_files/cutadapt-extract-abc-umi.log"
     threads: 20
     shell:
         "cutadapt"
-        " -g {handles[Sequence][h2]}"
+        " -g {handles[Sequence][h1]}{dbs}{handles[Sequence][h2]}...{handles[Sequence][h3]}"
         " --discard-untrimmed"
         " -e 0.2"
         " -j {threads}"
@@ -63,19 +65,25 @@ rule trim_to_abc:
 
 ## ABCs
 
+def get_abc_sequnce(wildcards):
+    return abc['Barcode-sequence'][wildcards.abc]
+
+# TODO Should take length from sequence.
 rule identify_abc:
     "Identifies ABC and trims it to give ABC-specific UMI fastq files."
     output:
-        reads="{dir}/{abc}-UMI-raw.fastq.gz"
+        reads="{dir}/{abc['Antibody-target']}-UMI-raw.fastq.gz"
     input:
         reads="{dir}/trimmed-abc.fastq.gz"
     log: "{dir}/id-{abc}.log"
+    params:
+        sequence = get_abc_sequence
     threads: 20
     shell:
         "cutadapt"
-        " -g ^{wildcards.abc}"
-        " -m 6"
-        " -M 6"
+        " -g ^{params.sequence}"
+        " -m config[umi_len]"
+        " -M config[umi_len]"
         " -e 0.2"
         " -j {threads}"
         " -o {output.reads}"

--- a/src/dbspro/Snakefile
+++ b/src/dbspro/Snakefile
@@ -72,18 +72,18 @@ def get_abc_sequnce(wildcards):
 rule identify_abc:
     "Identifies ABC and trims it to give ABC-specific UMI fastq files."
     output:
-        reads="{dir}/{abc['Antibody-target']}-UMI-raw.fastq.gz"
+        reads="{dir}/{sample}-UMI-raw.fastq.gz"
     input:
         reads="{dir}/trimmed-abc.fastq.gz"
-    log: "{dir}/id-{abc}.log"
-    params:
-        sequence = get_abc_sequence
+    log: "{dir}/id-{sample}.log"
     threads: 20
+    params:
+        seq = lambda wildcards: abc['Barcode-sequence'][wildcards.sample]
     shell:
         "cutadapt"
-        " -g ^{params.sequence}"
-        " -m config[umi_len]"
-        " -M config[umi_len]"
+        " -g ^{params.seq}"
+        " -m {config[umi_len]}"
+        " -M {config[umi_len]}"
         " -e 0.2"
         " -j {threads}"
         " -o {output.reads}"
@@ -147,7 +147,7 @@ rule analyze:
         reads_plot="{dir}/read-density-plot.png"
     input:
         dbs_fasta="{dir}/dbs-corrected.fasta",
-        abc_fastas=expand("{{dir}}/{abc}-UMI-corrected.fasta", abc=abc["Barcode-sequence"])
+        abc_fastas=expand("{{dir}}/{abc}-UMI-corrected.fasta", abc=abc['Antibody-target'])
     log: "{dir}/analyze.log"
     threads: 20
     shell:

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -56,7 +56,9 @@ def main(args):
         'abc_cluster_dist': args.abc_cluster_dist,
         'filter_reads': args.filter_reads,
         'abc_sequences': args.abc_file,
-        'handles': args.handles_file
+        'handles': args.handles_file,
+        'dbs_len': args.dbs_len,
+        'umi_len': args.umi_len,
     }
 
     # Lines below are modified from: https://github.com/NBISweden/IgDiscover/
@@ -106,3 +108,7 @@ def add_arguments(parser):
 
     configs.add_argument("--filter-reads", type=int, default=4, metavar="<READS>",
                          help="Minimum reads required for an ABC to be included in analysis output. DEFAULT: 4")
+    configs.add_argument("--dbs-len", type=int, default=20, metavar="<LENGTH>",
+                         help="Length of DBS barcode sequence in construct. DEFAULT: 20")
+    configs.add_argument("--umi-len", type=int, default=6, metavar="<LENGTH>",
+                         help="Length of UMI sequence in construct. DEFAULT: 6")

--- a/src/dbspro/cli/run.py
+++ b/src/dbspro/cli/run.py
@@ -62,7 +62,7 @@ def main(args):
     }
 
     # Lines below are modified from: https://github.com/NBISweden/IgDiscover/
-    snakefile_path = pkg_resources.resource_filename("dbspro", 'Snakefile')
+    snakefile_path = pkg_resources.resource_filename("dbspro", 'rules.smk')
     logger.root.handlers = []
     success = snakemake(snakefile_path,
                         snakemakepath='snakemake',  # Needed in snakemake 3.9.0

--- a/src/dbspro/rules.smk
+++ b/src/dbspro/rules.smk
@@ -8,7 +8,6 @@ handles = pd.read_csv(config["handles"], sep='\t').set_index("Name", drop=False)
 # Get required values
 abc_len = list(map(len, abc['Barcode-sequence']))[0]    # Assumes that all ABC are same length
 abc_umi_len = abc_len + config["umi_len"]
-
 dbs = "N"*config["dbs_len"]
 
 # Cutadapt trimming

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,4 +6,4 @@ rm -rf outdir
 dbspro run -d outdir -f testdata/reads-10k-DBS.fastq.gz -hf construct-info/handles.tsv -af construct-info/ABC-sequences.tsv
 
 m=$(cat outdir/umi-counts.txt | md5sum | cut -f 1 -d" ")
-test $m == 5f64eccd8b8e67d4aa954bcceb359b70
+test $m == d7e4d6d91069a97e2fd2cc3945222167


### PR DESCRIPTION
Related to issues #22 and #30 with some other stuff done.

- Renamed file from Snakefile to rules.smk.
- Fixed ABC file naming in pipeline so that files are named based on target name instead of sequence. E.g `ABC1-umi-corrected.fasta` instead of `GGATTC-umi-corrected.fasta`. This is also used in naming of the analysis results so those were simplified greatly. 
-  Removed rule trim_3prime as it could be skipped and merged into other cutadapt steps. 
- Changed extraction ABC-UMI sequence to use linked-adaptors. 
- Renamed some log files and moved into separate folder under analysis directory called `log_files`.
- Other small stuff