### PR TITLE
Cluster UMIs within DBS cluster

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -80,6 +80,7 @@ dependencies:
   - tornado=6.0.2
   - tqdm=4.32.1
   - urllib3=1.24.3
+  - umi_tools=1.0.0
   - wheel=0.33.4
   - wrapt=1.11.1
   - xopen=0.7.0

--- a/src/dbspro/cli/splitcluster.py
+++ b/src/dbspro/cli/splitcluster.py
@@ -1,0 +1,135 @@
+"""
+Split ABC file based on DBS cluster and cluster UMIs for each partion using UMI-tools.
+"""
+import dnaio
+import argparse
+from umi_tools import UMIClusterer
+import pandas as pd
+from collections import Counter, defaultdict
+import sys
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def main(args):
+    for item in vars(args).items():
+        print(item)
+
+    logger.info(f"Filtering reads not of length {args.length} bp.")
+
+    stats = Counter()
+
+    time_start = time.time()
+
+    # Read ABC fasta with UMI sequences and save read name and sequence.
+    umis = dict()
+    with dnaio.open(args.abcfile, mode="r") as file:
+        for read in file:
+            if args.length == len(read.sequence):
+                seq = bytes(read.sequence, encoding='utf-8')
+                umis[read.name] = seq
+            else:
+                stats['Reads filtered out'] += 1
+
+    logger.info(f"Reads filtered out: {stats['Reads filtered out']:,}")
+
+    time_filtered = time.time()
+    logger.info(f"Time for filtering: {time_filtered - time_start} s")
+    logger.info(f"Assigning UMIs to DBS clusters")
+    # Create structure for storing DBS, UMI and read name
+    #
+    #      {DBS1:{UMI1:[name1, name2, ...],
+    #             UMI2:[name3, ...],
+    #             ...
+    #             }
+    #       DBS2:{UMI1:[name1, name2, ...],
+    #             UMI2:[name3, ...],
+    #             ...
+    #             }
+    #      }
+    dbs_umis = defaultdict(dict)
+    with dnaio.open(args.dbsfile, mode="r") as file:
+        for read in file:
+            # Skip reads that are not to be clustered
+            if read.name not in umis:
+                continue
+
+            # Get sequences
+            dbs = read.sequence
+            umi = umis[read.name]
+
+
+
+            try:
+                dbs_umis[dbs][umi].append(read.name)
+            except KeyError:
+                dbs_umis[dbs][umi] = [read.name]
+
+            stats["Reads kept"] += 1
+
+    logger.info(f"Reads kept: {stats['Reads kept']}")
+    logger.info(f"DBS clusters linked to ABC: {len(dbs_umis)}")
+
+    time_assign = time.time()
+    logger.info(f"Time for assigning clusters: {time_assign - time_filtered} s")
+    logger.info(f"Starting clustering of UMIs within clusters.")
+
+    # Set clustering method
+    # Based on https://umi-tools.readthedocs.io/en/latest/API.html
+    clusterer = UMIClusterer(cluster_method='directional')
+
+    with dnaio.open(args.output, fileformat="fasta", mode="w") as output:
+        for dbs, umis in dbs_umis.items():
+
+            counts = {umi: len(reads) for umi, reads in umis.items()}
+
+            stats["Total UMIs"] += len(counts)
+
+            clustered_umis = umitools_clustering(counts, clusterer, threshold=args.threshold)
+
+            stats["Total clustered UMIs"] += len(clustered_umis)
+
+            for cluster in clustered_umis:
+                seqs = [seq.decode("utf-8") for seq in cluster]
+                canonical_sequnce = seqs[0]
+
+                for seq in cluster:
+                    for read_name in umis[seq]:
+                        read = dnaio.Sequence(read_name, canonical_sequnce)
+                        output.write(read)
+
+    time_end = time.time()
+    logger.info(f"Time for clustering: {time_end - time_assign} s")
+    logger.info(f"Total UMIs: {stats['Total UMIs']}")
+    logger.info(f"Total clustered UMIs: {stats['Total clustered UMIs']}")
+
+    logger.info(f"Total time to run: {time_end-time_start} s")
+
+
+def umitools_clustering(umi_counts, clusterer, threshold=None):
+    try:
+        return clusterer(umi_counts, threshold=threshold)
+    except ValueError as e:
+        print(umi_counts)
+        sys.exit(e)
+
+
+def add_arguments(parser):
+    parser.add_argument("dbsfile",
+                        help="Input file with corrected DBS sequences. Could be fasta or fastq")
+    parser.add_argument("abcfile",
+                        help="Input file with ABC UMI sequences. Could be fasta or fastq")
+
+    parser.add_argument("-o", "--output", default=None, type=str,
+                        help="Output cluster results as starcode format as txt file.")
+    parser.add_argument("-t", "--threshold", default=1, type=int,
+                        help="Edit distance threshold to cluster sequences. DEFAULT=1")
+    parser.add_argument("-l", "--length", type=int, required=True,
+                        help="Length of barcode sequence. DEFAULT=1")
+    parser.add_argument("-m", "--method", type=str, choices=["unique", "percentile", "cluster", "adjacency",
+                                                             "directional"],
+                        help="Select clustering method. DEFAULT=directional")
+
+

--- a/src/dbspro/cli/splitcluster.py
+++ b/src/dbspro/cli/splitcluster.py
@@ -4,7 +4,6 @@ Split ABC file based on DBS cluster and cluster UMIs for each partion using UMI-
 import dnaio
 import argparse
 from umi_tools import UMIClusterer
-import pandas as pd
 from collections import Counter, defaultdict
 import sys
 import time
@@ -12,64 +11,69 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Counter object for statistics.
+stats = Counter()
+
+
+def get_umis(file, length=0):
+    umis = dict()
+    for read in file:
+        if length == len(read.sequence):
+            umis[read.name] = read.sequence
+        else:
+            stats['Reads filtered out'] += 1
+    return umis
+
+
+def assign_to_dbs(file, umis):
+    """
+    Create structure for storing DBS, UMI and read name
+
+           {DBS1:{UMI1:[name1, name2, ...],
+                  UMI2:[name3, ...],
+                  ...
+                  }
+            DBS2:{UMI1:[name1, name2, ...],
+                  UMI2:[name3, ...],
+                  ...
+                  }
+           }
+    """
+    dbs_umis = defaultdict(dict)
+    for read in file:
+        # Skip reads that are not to be clustered
+        if read.name not in umis:
+            continue
+
+        # Get sequences
+        dbs = read.sequence
+        umi = umis[read.name]
+
+        try:
+            dbs_umis[dbs][umi].append(read.name)
+        except KeyError:
+            dbs_umis[dbs][umi] = [read.name]
+
+        stats["Reads kept"] += 1
+    return dbs_umis
+
 
 def main(args):
-    for item in vars(args).items():
-        print(item)
-
     logger.info(f"Filtering reads not of length {args.length} bp.")
-
-    stats = Counter()
 
     time_start = time.time()
 
     # Read ABC fasta with UMI sequences and save read name and sequence.
-    umis = dict()
     with dnaio.open(args.abcfile, mode="r") as file:
-        for read in file:
-            if args.length == len(read.sequence):
-                seq = bytes(read.sequence, encoding='utf-8')
-                umis[read.name] = seq
-            else:
-                stats['Reads filtered out'] += 1
-
-    logger.info(f"Reads filtered out: {stats['Reads filtered out']:,}")
+        umis = get_umis(file, length=args.length)
 
     time_filtered = time.time()
     logger.info(f"Time for filtering: {time_filtered - time_start} s")
     logger.info(f"Assigning UMIs to DBS clusters")
-    # Create structure for storing DBS, UMI and read name
-    #
-    #      {DBS1:{UMI1:[name1, name2, ...],
-    #             UMI2:[name3, ...],
-    #             ...
-    #             }
-    #       DBS2:{UMI1:[name1, name2, ...],
-    #             UMI2:[name3, ...],
-    #             ...
-    #             }
-    #      }
-    dbs_umis = defaultdict(dict)
+
     with dnaio.open(args.dbsfile, mode="r") as file:
-        for read in file:
-            # Skip reads that are not to be clustered
-            if read.name not in umis:
-                continue
+        dbs_umis = assign_to_dbs(file, umis)
 
-            # Get sequences
-            dbs = read.sequence
-            umi = umis[read.name]
-
-
-
-            try:
-                dbs_umis[dbs][umi].append(read.name)
-            except KeyError:
-                dbs_umis[dbs][umi] = [read.name]
-
-            stats["Reads kept"] += 1
-
-    logger.info(f"Reads kept: {stats['Reads kept']}")
     logger.info(f"DBS clusters linked to ABC: {len(dbs_umis)}")
 
     time_assign = time.time()
@@ -82,38 +86,35 @@ def main(args):
 
     with dnaio.open(args.output, fileformat="fasta", mode="w") as output:
         for dbs, umis in dbs_umis.items():
-
-            counts = {umi: len(reads) for umi, reads in umis.items()}
+            # Encode each UMI for UMITools and perpare counts
+            counts = {bytes(umi, encoding='utf-8'): len(reads) for umi, reads in umis.items()}
 
             stats["Total UMIs"] += len(counts)
 
-            clustered_umis = umitools_clustering(counts, clusterer, threshold=args.threshold)
+            # Cluster umis
+            clustered_umis = clusterer(counts, threshold=args.threshold)
 
             stats["Total clustered UMIs"] += len(clustered_umis)
 
+            # Loop over clusters and write reads with corrected UMI.
             for cluster in clustered_umis:
                 seqs = [seq.decode("utf-8") for seq in cluster]
                 canonical_sequnce = seqs[0]
 
-                for seq in cluster:
+                for seq in seqs:
                     for read_name in umis[seq]:
                         read = dnaio.Sequence(read_name, canonical_sequnce)
                         output.write(read)
 
     time_end = time.time()
     logger.info(f"Time for clustering: {time_end - time_assign} s")
-    logger.info(f"Total UMIs: {stats['Total UMIs']}")
-    logger.info(f"Total clustered UMIs: {stats['Total clustered UMIs']}")
-
     logger.info(f"Total time to run: {time_end-time_start} s")
 
-
-def umitools_clustering(umi_counts, clusterer, threshold=None):
-    try:
-        return clusterer(umi_counts, threshold=threshold)
-    except ValueError as e:
-        print(umi_counts)
-        sys.exit(e)
+    # Send stats to log
+    logger.info(f"Reads filtered out: {stats['Reads filtered out']:,}")
+    logger.info(f"Reads kept: {stats['Reads kept']}")
+    logger.info(f"Total UMIs: {stats['Total UMIs']}")
+    logger.info(f"Total clustered UMIs: {stats['Total clustered UMIs']}")
 
 
 def add_arguments(parser):
@@ -131,5 +132,3 @@ def add_arguments(parser):
     parser.add_argument("-m", "--method", type=str, choices=["unique", "percentile", "cluster", "adjacency",
                                                              "directional"],
                         help="Select clustering method. DEFAULT=directional")
-
-

--- a/src/dbspro/rules.smk
+++ b/src/dbspro/rules.smk
@@ -100,20 +100,17 @@ rule dbs_cluster:
 " a empty output file will also be created."
 rule abc_cluster:
     output:
-        clusters="ABCs/{sample}-UMI-clusters.txt"
+        reads="ABCs/{sample}-UMI-corrected.fasta"
     input:
-        reads="ABCs/{sample}-UMI-raw.fastq.gz"
-    log: "ABCs/log_files/starcode-abc-cluster-{sample}.log"
-    threads: 20
+        abc_reads="ABCs/{sample}-UMI-raw.fastq.gz",
+        dbs_corrected="dbs-corrected.fasta"
+    log: "ABCs/log_files/splitcluster-{sample}.log"
     shell:
-        "if [ -s {input.reads} ]; then"
-        " pigz -cd {input.reads} | starcode"
-        " --print-clusters"
-        " -t {threads}"
-        " -d {config[abc_cluster_dist]}"
-        " -o {output.clusters} 2> {log};"
-        " else touch {output.clusters};"
-        " fi"
+        "dbspro splitcluster"
+        " {input.dbs_corrected}"
+        " {input.abc_reads}"
+        " -o {output.reads}"
+        " -l {config[umi_len]} 2> {log}"
 
 
 # DBS-Pro

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,4 +7,4 @@ dbspro run -d outdir -f testdata/reads-10k-DBS.fastq.gz \
     ../construct-info/handles.tsv ../construct-info/ABC-sequences.fasta
 
 m=$(cat outdir/umi-counts.txt | md5sum | cut -f 1 -d" ")
-test $m == 6eb38680a896742e23cdfed7317ebc67
+test $m == 62ce11e3ac4fb7428a6bf4bfed84f529


### PR DESCRIPTION
Implementation of #33 

New function to cluster UMI in ABC files. This take a error corrected DBS file (`dbs-correct.fasta`) and a ABC file (e.g `ABC1-UMI-raw.fastq.gz`). It uses the ABC file to collect UMI sequences and the DBS file to split them based on DBS sequence clusters. For each sure cluster the UMIs are then clustered using the [UMITools](https://github.com/CGATOxford/UMI-tools) API.   I included the available clustering method options as possible arguments to the function but kept  'directional' as default. I am not sure if we would ever want to try using another method but what the heck! 

This is currently implemented in the pipeline as a replacement for the ABC clustering using `starcode` and error correction using `dbspro correctfastq`. It would however be possible to implement it as an option by including an option for "clustering method" in the `run.py` file. Then we could keep both of these, but I am not sure if that is desirable. Thoughts?  